### PR TITLE
Realm implementation - Joseph Wardell

### DIFF
--- a/BridgingHeader.h
+++ b/BridgingHeader.h
@@ -1,0 +1,24 @@
+//
+//  BridgingHeader.h
+//  FeedStoreChallenge
+//
+//  Created by Joseph Wardell on 12/31/20.
+//  Copyright © 2020 Essential Developer. All rights reserved.
+//
+
+@import Foundation;
+
+#ifndef BridgingHeader_h
+#define BridgingHeader_h
+NS_INLINE NSException * _Nullable ExecuteWithObjCExceptionHandling(void(NS_NOESCAPE^_Nonnull tryBlock)(void)) {
+	@try {
+		tryBlock();
+	}
+	@catch (NSException *exception) {
+		return exception;
+	}
+	return nil;
+}
+
+
+#endif /* BridgingHeader_h */

--- a/FeedStoreChallenge.xcodeproj/project.pbxproj
+++ b/FeedStoreChallenge.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7C8A1E89259E0D770007F3EF /* RealmFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */; };
 		7C8A1E8E259E0FE00007F3EF /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 7C8A1E8D259E0FE00007F3EF /* Realm */; };
 		7C8A1E90259E0FE00007F3EF /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7C8A1E8F259E0FE00007F3EF /* RealmSwift */; };
+		7CBAEC86259E5B9E00E1294F /* ObjectiveCExceptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBAEC85259E5B9E00E1294F /* ObjectiveCExceptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,8 @@
 		08CE2BAE2285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableInsertFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08CE2BB42285BEF100183A1B /* FeedStoreChallengeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreChallengeTests.swift; sourceTree = "<group>"; };
 		7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmFeedStore.swift; sourceTree = "<group>"; };
+		7CBAEC82259E5B6100E1294F /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
+		7CBAEC85259E5B9E00E1294F /* ObjectiveCExceptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCExceptions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +78,7 @@
 		08CE2B812285BBD100183A1B = {
 			isa = PBXGroup;
 			children = (
+				7CBAEC82259E5B6100E1294F /* BridgingHeader.h */,
 				08CE2B8D2285BBD100183A1B /* FeedStoreChallenge */,
 				08CE2B982285BBD100183A1B /* Tests */,
 				08CE2B8C2285BBD100183A1B /* Products */,
@@ -97,6 +101,7 @@
 				08CE2BA72285BCC600183A1B /* LocalFeedImage.swift */,
 				08CE2BA52285BCB600183A1B /* FeedStore.swift */,
 				7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */,
+				7CBAEC85259E5B9E00E1294F /* ObjectiveCExceptions.swift */,
 				08CE2B8F2285BBD100183A1B /* Info.plist */,
 			);
 			path = FeedStoreChallenge;
@@ -244,6 +249,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08CE2BA62285BCB600183A1B /* FeedStore.swift in Sources */,
+				7CBAEC86259E5B9E00E1294F /* ObjectiveCExceptions.swift in Sources */,
 				7C8A1E89259E0D770007F3EF /* RealmFeedStore.swift in Sources */,
 				08CE2BA82285BCC600183A1B /* LocalFeedImage.swift in Sources */,
 			);
@@ -421,6 +427,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.FeedStoreChallenge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = BridgingHeader.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -449,6 +456,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.FeedStoreChallenge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = BridgingHeader.h;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/FeedStoreChallenge.xcodeproj/project.pbxproj
+++ b/FeedStoreChallenge.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		08CE2BB22285BCE700183A1B /* XCTestCase+FailableDeleteFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BAD2285BCE700183A1B /* XCTestCase+FailableDeleteFeedStoreSpecs.swift */; };
 		08CE2BB32285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BAE2285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift */; };
 		08CE2BB52285BEF100183A1B /* FeedStoreChallengeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BB42285BEF100183A1B /* FeedStoreChallengeTests.swift */; };
+		7C8A1E89259E0D770007F3EF /* RealmFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		08CE2BAD2285BCE700183A1B /* XCTestCase+FailableDeleteFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableDeleteFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08CE2BAE2285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableInsertFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08CE2BB42285BEF100183A1B /* FeedStoreChallengeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreChallengeTests.swift; sourceTree = "<group>"; };
+		7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmFeedStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +92,7 @@
 			children = (
 				08CE2BA72285BCC600183A1B /* LocalFeedImage.swift */,
 				08CE2BA52285BCB600183A1B /* FeedStore.swift */,
+				7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */,
 				08CE2B8F2285BBD100183A1B /* Info.plist */,
 			);
 			path = FeedStoreChallenge;
@@ -230,6 +233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08CE2BA62285BCB600183A1B /* FeedStore.swift in Sources */,
+				7C8A1E89259E0D770007F3EF /* RealmFeedStore.swift in Sources */,
 				08CE2BA82285BCC600183A1B /* LocalFeedImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FeedStoreChallenge.xcodeproj/project.pbxproj
+++ b/FeedStoreChallenge.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,6 +19,8 @@
 		08CE2BB32285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BAE2285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift */; };
 		08CE2BB52285BEF100183A1B /* FeedStoreChallengeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BB42285BEF100183A1B /* FeedStoreChallengeTests.swift */; };
 		7C8A1E89259E0D770007F3EF /* RealmFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A1E88259E0D770007F3EF /* RealmFeedStore.swift */; };
+		7C8A1E8E259E0FE00007F3EF /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 7C8A1E8D259E0FE00007F3EF /* Realm */; };
+		7C8A1E90259E0FE00007F3EF /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7C8A1E8F259E0FE00007F3EF /* RealmSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +56,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7C8A1E90259E0FE00007F3EF /* RealmSwift in Frameworks */,
+				7C8A1E8E259E0FE00007F3EF /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,6 +153,10 @@
 			dependencies = (
 			);
 			name = FeedStoreChallenge;
+			packageProductDependencies = (
+				7C8A1E8D259E0FE00007F3EF /* Realm */,
+				7C8A1E8F259E0FE00007F3EF /* RealmSwift */,
+			);
 			productName = FeedStoreChallenge;
 			productReference = 08CE2B8B2285BBD100183A1B /* FeedStoreChallenge.framework */;
 			productType = "com.apple.product-type.framework";
@@ -200,6 +208,9 @@
 				Base,
 			);
 			mainGroup = 08CE2B812285BBD100183A1B;
+			packageReferences = (
+				7C8A1E8C259E0FE00007F3EF /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+			);
 			productRefGroup = 08CE2B8C2285BBD100183A1B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -513,6 +524,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		7C8A1E8C259E0FE00007F3EF /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-cocoa.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7C8A1E8D259E0FE00007F3EF /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7C8A1E8C259E0FE00007F3EF /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = Realm;
+		};
+		7C8A1E8F259E0FE00007F3EF /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7C8A1E8C259E0FE00007F3EF /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = RealmSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 08CE2B822285BBD100183A1B /* Project object */;
 }

--- a/FeedStoreChallenge/ObjectiveCExceptions.swift
+++ b/FeedStoreChallenge/ObjectiveCExceptions.swift
@@ -1,0 +1,27 @@
+//
+//  ObjectiveCExceptions.swift
+//  FeedStoreChallenge
+//
+//  Created by Joseph Wardell on 12/31/20.
+//  Copyright © 2020 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+public struct NSExceptionError: Swift.Error {
+   public let exception: NSException
+   public init(exception: NSException) {
+	  self.exception = exception
+   }
+}
+
+public struct ObjectiveCExceptions {
+   public static func performTry(workItem: () -> Void) throws {
+	  let exception = ExecuteWithObjCExceptionHandling {
+		 workItem()
+	  }
+	  if let exception = exception {
+		 throw NSExceptionError(exception: exception)
+	  }
+   }
+}

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -7,21 +7,69 @@
 //
 
 import Foundation
+import RealmSwift
 
+class CachedFeedImage: Object {
+	@objc dynamic var id: String?
+	@objc dynamic var desc: String?
+	@objc dynamic var location: String?
+	@objc dynamic var url: String?
+	@objc dynamic var timestamp: Date?
+
+	class func createFeedImage(from localFeedImage: LocalFeedImage, at timestamp: Date) -> CachedFeedImage {
+		
+		let out = CachedFeedImage()
+		out.id = localFeedImage.id.uuidString
+		out.desc = localFeedImage.description
+		out.location = localFeedImage.location
+		out.url = localFeedImage.url.absoluteString
+		
+		out.timestamp = timestamp
+		
+		return out
+	}
+		
+	var localFeedImage: LocalFeedImage {
+		LocalFeedImage(id: UUID(uuidString: id!)!, description: desc, location: location, url: URL(string: url!)!)
+	}
+}
+
+// MARK:-
 public final class RealmFeedStore: FeedStore {
 	
-	public init() {}
+	let realm: Realm
+	public init() {
+		self.realm = try! Realm()
+	}
 	
+
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		fatalError()
 	}
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-		fatalError()
+		try! realm.write {
+			for image in feed {
+				realm.add(CachedFeedImage.createFeedImage(from: image, at: timestamp))
+			}
+		}
+		completion(nil)
 	}
 	
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		completion(.empty)
+		let cached = realm.objects(CachedFeedImage.self)
+		if cached.count > 0 {
+			let feedImages = cached.map {
+				$0.localFeedImage
+			}
+			
+			let timestamp = cached.first!.timestamp!
+			
+			completion(.found(feed: Array(feedImages), timestamp: timestamp))
+		}
+		else {
+			completion(.empty)
+		}
 	}
 	
 	

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -59,7 +59,7 @@ public final class RealmFeedStore: FeedStore {
 	
 	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		fatalError()
+		completion(nil)
 	}
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -57,7 +57,7 @@ public final class RealmFeedStore: FeedStore {
 		self.realm = try! Realm()
 	}
 	
-
+	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		fatalError()
 	}
@@ -74,20 +74,11 @@ public final class RealmFeedStore: FeedStore {
 	}
 	
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		let cached = realm.objects(RealmFeedStoreCachedFeedImage.self)
-		if cached.count > 0 {
-			let feedImages = cached.map {
-				$0.localFeedImage
-			}
-			
-			let timestamp = realm.objects(RealmFeedStoreTimestamp.self).first!.timestamp!			
-			
-			completion(.found(feed: Array(feedImages), timestamp: timestamp))
-		}
-		else {
-			completion(.empty)
-		}
+
+		guard let timestamp = realm.objects(RealmFeedStoreTimestamp.self).first?.timestamp else { return completion(.empty) }
+
+		let cached = realm.objects(RealmFeedStoreCachedFeedImage.self)		
+		let feedImages = Array(cached.map(\.localFeedImage))
+		completion(.found(feed: feedImages, timestamp: timestamp))
 	}
-	
-	
 }

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -59,6 +59,7 @@ public final class RealmFeedStore: FeedStore {
 	
 	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
+		clearOld()
 		completion(nil)
 	}
 	

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -75,13 +75,11 @@ public final class RealmFeedStore: FeedStore {
 		queue.async { [unowned self] in
 			do {
 				let realm = try Realm(configuration: self.configuration, queue: self.queue)
-//				try realm.write {
 				try ObjectiveCExceptions.performTry {
 					realm.beginWrite()
 				}
 				callback(.success(realm))
 				try realm.commitWrite()
-//				}
 			}
 			catch {
 				callback(.failure(error))

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -60,17 +60,21 @@ public final class RealmFeedStore: FeedStore {
 	}
 		
 	private func accessRealm(_ callback: (Realm)->()) throws {
-		try autoreleasepool {
-			let realm = try Realm(configuration: configuration)
-			callback(realm)
+		try queue.sync {
+			try autoreleasepool {
+				let realm = try Realm(configuration: configuration, queue: queue)
+				callback(realm)
+			}
 		}
 	}
 	
 	private func writeToRealm(_ callback: (Realm)->()) throws {
-		try autoreleasepool {
-			let realm = try Realm(configuration: configuration)
-			try realm.write {
-				callback(realm)
+		try queue.sync {
+			try autoreleasepool {
+				let realm = try Realm(configuration: configuration, queue: queue)
+				try realm.write {
+					callback(realm)
+				}
 			}
 		}
 	}

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -1,0 +1,28 @@
+//
+//  RealmFeedStore.swift
+//  FeedStoreChallenge
+//
+//  Created by Joseph Wardell on 12/31/20.
+//  Copyright © 2020 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+public final class RealmFeedStore: FeedStore {
+	
+	public init() {}
+	
+	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
+		fatalError()
+	}
+	
+	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
+		fatalError()
+	}
+	
+	public func retrieve(completion: @escaping RetrievalCompletion) {
+		completion(.empty)
+	}
+	
+	
+}

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -53,8 +53,9 @@ final class RealmFeedStoreTimestamp: Object {
 public final class RealmFeedStore: FeedStore {
 	
 	let realm: Realm
-	public init() {
-		self.realm = try! Realm()
+	public init(_ fileURL: URL) {
+		let configuration = Realm.Configuration(fileURL: fileURL)
+		self.realm = try! Realm(configuration: configuration)
 	}
 	
 	

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -11,16 +11,17 @@ import RealmSwift
 
 /// This is an internal type to RealmFeedStore
 /// It should not be used by any code outside this file
-final class CachedFeedImage: Object {
+// we would make it fileprivate, but Realm complains with an error
+final class RealmFeedStoreCachedFeedImage: Object {
 	@objc fileprivate dynamic var id: String?
 	@objc fileprivate dynamic var desc: String?
 	@objc fileprivate dynamic var location: String?
 	@objc fileprivate dynamic var url: String?
 	@objc fileprivate dynamic var timestamp: Date?
 
-	fileprivate class func createFeedImage(from localFeedImage: LocalFeedImage, at timestamp: Date) -> CachedFeedImage {
+	fileprivate class func createFeedImage(from localFeedImage: LocalFeedImage, at timestamp: Date) -> RealmFeedStoreCachedFeedImage {
 		
-		let out = CachedFeedImage()
+		let out = RealmFeedStoreCachedFeedImage()
 		out.id = localFeedImage.id.uuidString
 		out.desc = localFeedImage.description
 		out.location = localFeedImage.location
@@ -52,14 +53,14 @@ public final class RealmFeedStore: FeedStore {
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
 		try! realm.write {
 			for image in feed {
-				realm.add(CachedFeedImage.createFeedImage(from: image, at: timestamp))
+				realm.add(RealmFeedStoreCachedFeedImage.createFeedImage(from: image, at: timestamp))
 			}
 		}
 		completion(nil)
 	}
 	
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		let cached = realm.objects(CachedFeedImage.self)
+		let cached = realm.objects(RealmFeedStoreCachedFeedImage.self)
 		if cached.count > 0 {
 			let feedImages = cached.map {
 				$0.localFeedImage

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -9,14 +9,16 @@
 import Foundation
 import RealmSwift
 
-class CachedFeedImage: Object {
-	@objc dynamic var id: String?
-	@objc dynamic var desc: String?
-	@objc dynamic var location: String?
-	@objc dynamic var url: String?
-	@objc dynamic var timestamp: Date?
+/// This is an internal type to RealmFeedStore
+/// It should not be used by any code outside this file
+final class CachedFeedImage: Object {
+	@objc fileprivate dynamic var id: String?
+	@objc fileprivate dynamic var desc: String?
+	@objc fileprivate dynamic var location: String?
+	@objc fileprivate dynamic var url: String?
+	@objc fileprivate dynamic var timestamp: Date?
 
-	class func createFeedImage(from localFeedImage: LocalFeedImage, at timestamp: Date) -> CachedFeedImage {
+	fileprivate class func createFeedImage(from localFeedImage: LocalFeedImage, at timestamp: Date) -> CachedFeedImage {
 		
 		let out = CachedFeedImage()
 		out.id = localFeedImage.id.uuidString
@@ -29,7 +31,7 @@ class CachedFeedImage: Object {
 		return out
 	}
 		
-	var localFeedImage: LocalFeedImage {
+	fileprivate var localFeedImage: LocalFeedImage {
 		LocalFeedImage(id: UUID(uuidString: id!)!, description: desc, location: location, url: URL(string: url!)!)
 	}
 }

--- a/FeedStoreChallenge/RealmFeedStore.swift
+++ b/FeedStoreChallenge/RealmFeedStore.swift
@@ -63,6 +63,9 @@ public final class RealmFeedStore: FeedStore {
 	}
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
+		
+		clearOld()
+		
 		try! realm.write {
 			for image in feed {
 				realm.add(RealmFeedStoreCachedFeedImage.create(from: image, at: timestamp))
@@ -75,10 +78,16 @@ public final class RealmFeedStore: FeedStore {
 	
 	public func retrieve(completion: @escaping RetrievalCompletion) {
 
-		guard let timestamp = realm.objects(RealmFeedStoreTimestamp.self).first?.timestamp else { return completion(.empty) }
+		guard let timestamp = realm.objects(RealmFeedStoreTimestamp.self).last?.timestamp else { return completion(.empty) }
 
-		let cached = realm.objects(RealmFeedStoreCachedFeedImage.self)		
+		let cached = realm.objects(RealmFeedStoreCachedFeedImage.self)
 		let feedImages = Array(cached.map(\.localFeedImage))
 		completion(.found(feed: feedImages, timestamp: timestamp))
+	}
+	
+	private func clearOld() {
+		try! realm.write {
+			realm.deleteAll()
+		}
 	}
 }

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -26,9 +26,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
 	}
 	
 	func test_retrieve_deliversFoundValuesOnNonEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -53,9 +53,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_deliversNoErrorOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
 	}
 	
 	func test_insert_deliversNoErrorOnNonEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -83,9 +83,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_deliversNoErrorOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
 	}
 	
 	func test_delete_emptiesPreviouslyInsertedCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -171,12 +171,30 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
 
 	func test_retrieve_deliversFailureOnRetrievalError() {
-		let sut = makeSUT(at: cachesDirectory())
+		
+		// if there's already invalid data there, then the realm will return an error
+		try! "not valid realm data".write(to: testSpecificStoreURL(), atomically: false, encoding: .utf8)
+		let sut = makeSUT(at: testSpecificStoreURL())
 
 		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
 	}
 
 	func test_retrieve_hasNoSideEffectsOnFailure() {
+
+		// if there's already invalid data there, then the realm will return an error
+		try! "not valid realm data".write(to: testSpecificStoreURL(), atomically: false, encoding: .utf8)
+		let sut = makeSUT(at: testSpecificStoreURL())
+
+		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
+	}
+
+	func test_retrieve_deliversFailureOnRetrievalError_forPermissionsError() {
+		let sut = makeSUT(at: cachesDirectory())
+
+		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
+	}
+
+	func test_retrieve_hasNoSideEffectsOnFailure_forPermissionsError() {
 		let sut = makeSUT(at: cachesDirectory())
 
 		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -4,8 +4,26 @@
 
 import XCTest
 import FeedStoreChallenge
+import RealmSwift
 
 class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
+	
+	override func setUp() {
+		let realmURL = Realm.Configuration.defaultConfiguration.fileURL!
+		let realmURLs = [
+			realmURL,
+			realmURL.appendingPathExtension("lock"),
+			realmURL.appendingPathExtension("note"),
+			realmURL.appendingPathExtension("management")
+		]
+		for URL in realmURLs {
+			do {
+				try FileManager.default.removeItem(at: URL)
+			} catch {
+				// handle error
+			}
+		}
+	}
 	
 	//  ***********************
 	//
@@ -32,9 +50,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_retrieve_deliversFoundValuesOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
+				let sut = makeSUT()
+		
+				assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnNonEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -77,9 +77,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_hasNoSideEffectsOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
 	}
 	
 	func test_delete_deliversNoErrorOnNonEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -41,9 +41,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_retrieve_deliversFoundValuesOnNonEmptyCache() {
-				let sut = makeSUT()
+		let sut = makeSUT()
 		
-				assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
+		assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnNonEmptyCache() {
@@ -59,9 +59,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_deliversNoErrorOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
 	}
 	
 	func test_insert_overridesPreviouslyInsertedCacheValues() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -47,9 +47,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
 	}
 	
 	func test_insert_deliversNoErrorOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -95,9 +95,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_storeSideEffects_runSerially() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatSideEffectsRunSerially(on: sut)
+		let sut = makeSUT()
+		
+		assertThatSideEffectsRunSerially(on: sut)
 	}
 	
 	// - MARK: Helpers

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -65,9 +65,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_overridesPreviouslyInsertedCacheValues() {
-				let sut = makeSUT()
+		let sut = makeSUT()
 		
-				assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
+		assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
 	}
 	
 	func test_delete_deliversNoErrorOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -71,9 +71,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_deliversNoErrorOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
 	}
 	
 	func test_delete_hasNoSideEffectsOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -65,9 +65,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_overridesPreviouslyInsertedCacheValues() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
+				let sut = makeSUT()
+		
+				assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
 	}
 	
 	func test_delete_deliversNoErrorOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -20,9 +20,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	//  ***********************
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() {
@@ -94,7 +94,7 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	// - MARK: Helpers
 	
 	private func makeSUT() -> FeedStore {
-		fatalError("Must be implemented")
+		RealmFeedStore()
 	}
 	
 }

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -102,8 +102,16 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	// - MARK: Helpers
 	
-	private func makeSUT() -> FeedStore {
-		RealmFeedStore(test_specific_storeURL())
+	private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> FeedStore {
+		let sut = RealmFeedStore(test_specific_storeURL())
+		trackForMemoryLeaks(sut, file: file, line: line)
+		return sut
+	}
+	
+	func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+		addTeardownBlock { [weak instance] in
+			XCTAssertNil(instance, "\(String(describing: instance)) was never deallocated.", file: file, line: line)
+		}
 	}
 	
 	private func test_specific_storeURL() -> URL {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -102,8 +102,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	// - MARK: Helpers
 	
-	private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> FeedStore {
-		let sut = RealmFeedStore(test_specific_storeURL())
+	private func makeSUT(at fileURL: URL? = nil, file: StaticString = #filePath, line: UInt = #line) -> FeedStore {
+		let fileURL = fileURL ?? testSpecificStoreURL()
+		let sut = RealmFeedStore(fileURL)
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
 	}
@@ -114,18 +115,18 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 		}
 	}
 	
-	private func test_specific_storeURL() -> URL {
+	private func testSpecificStoreURL() -> URL {
 		let out = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("\(type(of: self)).realm")
 		return out
 	}
 
 	
 	private func setupEmptyStoreState() {
-		clearRealmFiles(at: test_specific_storeURL())
+		clearRealmFiles(at: testSpecificStoreURL())
 	}
 	
 	private func undoStoreSideEffects() {
-		clearRealmFiles(at: test_specific_storeURL())
+		clearRealmFiles(at: testSpecificStoreURL())
 	}
 	
 	private func clearRealmFiles(at realmURL: URL) {
@@ -144,6 +145,10 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 		}
 	}
 
+	private func invalidStoreURL() -> URL {
+		URL(string: "invalid://store-url")!
+	}
+
 }
 
 //  ***********************
@@ -154,21 +159,21 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 //
 //  ***********************
 
-//extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
-//
-//	func test_retrieve_deliversFailureOnRetrievalError() {
-////		let sut = makeSUT()
-////
-////		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
-//	}
-//
-//	func test_retrieve_hasNoSideEffectsOnFailure() {
-////		let sut = makeSUT()
-////
-////		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
-//	}
-//
-//}
+extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
+
+	func test_retrieve_deliversFailureOnRetrievalError() {
+		let sut = makeSUT(at: invalidStoreURL())
+
+		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
+	}
+
+	func test_retrieve_hasNoSideEffectsOnFailure() {
+		let sut = makeSUT(at: invalidStoreURL())
+
+		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
+	}
+
+}
 
 //extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 //

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -89,9 +89,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_emptiesPreviouslyInsertedCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
 	}
 	
 	func test_storeSideEffects_runSerially() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -103,19 +103,24 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	// - MARK: Helpers
 	
 	private func makeSUT() -> FeedStore {
-		RealmFeedStore()
+		RealmFeedStore(test_specific_storeURL())
 	}
 	
+	private func test_specific_storeURL() -> URL {
+		let out = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("\(type(of: self)).realm")
+		return out
+	}
+
+	
 	private func setupEmptyStoreState() {
-		clearRealmFiles()
+		clearRealmFiles(at: test_specific_storeURL())
 	}
 	
 	private func undoStoreSideEffects() {
-		clearRealmFiles()
+		clearRealmFiles(at: test_specific_storeURL())
 	}
 	
-	private func clearRealmFiles() {
-		let realmURL = Realm.Configuration.defaultConfiguration.fileURL!
+	private func clearRealmFiles(at realmURL: URL) {
 		let realmURLs = [
 			realmURL,
 			realmURL.appendingPathExtension("lock"),

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -9,20 +9,11 @@ import RealmSwift
 class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	override func setUp() {
-		let realmURL = Realm.Configuration.defaultConfiguration.fileURL!
-		let realmURLs = [
-			realmURL,
-			realmURL.appendingPathExtension("lock"),
-			realmURL.appendingPathExtension("note"),
-			realmURL.appendingPathExtension("management")
-		]
-		for URL in realmURLs {
-			do {
-				try FileManager.default.removeItem(at: URL)
-			} catch {
-				// handle error
-			}
-		}
+		setupEmptyStoreState()
+	}
+	
+	override func tearDown() {
+		undoStoreSideEffects()
 	}
 	
 	//  ***********************
@@ -115,6 +106,31 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 		RealmFeedStore()
 	}
 	
+	private func setupEmptyStoreState() {
+		clearRealmFiles()
+	}
+	
+	private func undoStoreSideEffects() {
+		clearRealmFiles()
+	}
+	
+	private func clearRealmFiles() {
+		let realmURL = Realm.Configuration.defaultConfiguration.fileURL!
+		let realmURLs = [
+			realmURL,
+			realmURL.appendingPathExtension("lock"),
+			realmURL.appendingPathExtension("note"),
+			realmURL.appendingPathExtension("management")
+		]
+		for URL in realmURLs {
+			do {
+				try FileManager.default.removeItem(at: URL)
+			} catch {
+				// handle error
+			}
+		}
+	}
+
 }
 
 //  ***********************

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -206,7 +206,16 @@ extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 
 		// In order to test retrieval after a failed insert
 		// we need an existing realm file that the retrieve can read
-		// but we need it to be emoty when insert() is called
+		// but we need it to be empty when insert() is called
+		writeEmptyRealmFile(at: testSpecificStoreURL())
+
+		// trying to insert into a realm that is readonly will cause an error
+		let sut = makeSUT(readonly: true)
+		
+		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
+	}
+
+	private func writeEmptyRealmFile(at fileURL: URL) {
 		
 		// create an existing realm at the standard test location
 		// and write to it, but leave it empty
@@ -222,13 +231,8 @@ extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 			exp2.fulfill()
 		}
 		wait(for: [exp1, exp2], timeout: 1.0)
-
-		// trying to insert into a realm that is readonly will cause an error
-		let sut = makeSUT(readonly: true)
-		
-		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
 	}
-
+	
 }
 
 //extension FeedStoreChallengeTests: FailableDeleteFeedStoreSpecs {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -200,8 +200,7 @@ extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 
 	func test_insert_deliversErrorOnInsertionError() {
 
-		// trying to write into a realm that is readonly
-		// will cause an error
+		// trying to write into a realm that is readonly will cause an error
 		let sut = RealmFeedStore(testSpecificReadOnlyStoreURL(), readOnly: true)
 		trackForMemoryLeaks(sut)
 
@@ -246,18 +245,35 @@ extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 	
 }
 
-//extension FeedStoreChallengeTests: FailableDeleteFeedStoreSpecs {
-//
-//	func test_delete_deliversErrorOnDeletionError() {
-////		let sut = makeSUT()
-////
-////		assertThatDeleteDeliversErrorOnDeletionError(on: sut)
-//	}
-//
-//	func test_delete_hasNoSideEffectsOnDeletionError() {
-////		let sut = makeSUT()
-////
-////		assertThatDeleteHasNoSideEffectsOnDeletionError(on: sut)
-//	}
-//
-//}
+extension FeedStoreChallengeTests: FailableDeleteFeedStoreSpecs {
+
+	func test_delete_deliversErrorOnDeletionError() {
+
+		// trying to delete from a realm that is readonly will cause an error
+		let sut = RealmFeedStore(testSpecificReadOnlyStoreURL(), readOnly: true)
+		trackForMemoryLeaks(sut)
+
+		assertThatDeleteDeliversErrorOnDeletionError(on: sut)
+		
+		clearRealmFiles(at: testSpecificReadOnlyStoreURL())
+	}
+
+	func test_delete_hasNoSideEffectsOnDeletionError() {
+
+		// In order to test retrieval after a failed deletion
+		// we need an existing realm file that the retrieve can read
+		// but we need it to be empty when insert() is called
+		writeEmptyRealmFile(at: testSpecificReadOnlyStoreURL())
+		
+		// trying to delete from a realm that is readonly will cause an error
+		let sut = RealmFeedStore(testSpecificReadOnlyStoreURL(), readOnly: true)
+		trackForMemoryLeaks(sut)
+
+		print(testSpecificReadOnlyStoreURL())
+		
+		assertThatDeleteHasNoSideEffectsOnDeletionError(on: sut)
+		
+		clearRealmFiles(at: testSpecificReadOnlyStoreURL())
+	}
+
+}

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -149,6 +149,10 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 		URL(string: "invalid://store-url")!
 	}
 
+	private func cachesDirectory() -> URL {
+		FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+	}
+
 }
 
 //  ***********************
@@ -162,12 +166,24 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
 
 	func test_retrieve_deliversFailureOnRetrievalError() {
-		let sut = makeSUT(at: invalidStoreURL())
+		let sut = makeSUT(at: cachesDirectory())
 
 		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
 	}
 
 	func test_retrieve_hasNoSideEffectsOnFailure() {
+		let sut = makeSUT(at: cachesDirectory())
+
+		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
+	}
+
+	func test_retrieve_deliversFailureOnRetrievalError_forInvalidURL() {
+		let sut = makeSUT(at: invalidStoreURL())
+
+		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
+	}
+
+	func test_retrieve_hasNoSideEffectsOnFailure_forInvalidURL() {
 		let sut = makeSUT(at: invalidStoreURL())
 
 		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -33,14 +33,14 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_retrieve_deliversFeedInsertedOnAnotherInstance() {
-		//        let storeToInsert = makeSUT()
-		//        let storeToLoad = makeSUT()
-		//        let feed = uniqueImageFeed()
-		//        let timestamp = Date()
-		//
-		//        insert((feed, timestamp), to: storeToInsert)
-		//
-		//        expect(storeToLoad, toRetrieve: .found(feed: feed, timestamp: timestamp))
+		let storeToInsert = makeSUT()
+		let storeToLoad = makeSUT()
+		let feed = uniqueImageFeed()
+		let timestamp = Date()
+		
+		insert((feed, timestamp), to: storeToInsert)
+		
+		expect(storeToLoad, toRetrieve: .found(feed: feed, timestamp: timestamp))
 	}
 	
 	func test_insert_overridesFeedInsertedOnAnotherInstance() {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -44,17 +44,17 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_insert_overridesFeedInsertedOnAnotherInstance() {
-		//        let storeToInsert = makeSUT()
-		//        let storeToOverride = makeSUT()
-		//        let storeToLoad = makeSUT()
-		//
-		//        insert((uniqueImageFeed(), Date()), to: storeToInsert)
-		//
-		//        let latestFeed = uniqueImageFeed()
-		//        let latestTimestamp = Date()
-		//        insert((latestFeed, latestTimestamp), to: storeToOverride)
-		//
-		//        expect(storeToLoad, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp))
+		let storeToInsert = makeSUT()
+		let storeToOverride = makeSUT()
+		let storeToLoad = makeSUT()
+		
+		insert((uniqueImageFeed(), Date()), to: storeToInsert)
+		
+		let latestFeed = uniqueImageFeed()
+		let latestTimestamp = Date()
+		insert((latestFeed, latestTimestamp), to: storeToOverride)
+		
+		expect(storeToLoad, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp))
 	}
 	
 	func test_delete_deletesFeedInsertedOnAnotherInstance() {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -58,15 +58,15 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_delete_deletesFeedInsertedOnAnotherInstance() {
-		//        let storeToInsert = makeSUT()
-		//        let storeToDelete = makeSUT()
-		//        let storeToLoad = makeSUT()
-		//
-		//        insert((uniqueImageFeed(), Date()), to: storeToInsert)
-		//
-		//        deleteCache(from: storeToDelete)
-		//
-		//        expect(storeToLoad, toRetrieve: .empty)
+		        let storeToInsert = makeSUT()
+		        let storeToDelete = makeSUT()
+		        let storeToLoad = makeSUT()
+		
+		        insert((uniqueImageFeed(), Date()), to: storeToInsert)
+		
+		        deleteCache(from: storeToDelete)
+		
+		        expect(storeToLoad, toRetrieve: .empty)
 	}
 	
 	// - MARK: Helpers


### PR DESCRIPTION
Here's my Realm solution to the feed store challenge.

I ran across a couple interesting issues:
1) Realm doesn't like Realm.Object subclasses that exist within a namespace other than the global namespace.  So I was unable to include my RealmFeedStoreCachedFeedImage class within my RealmFeedStore implementation as I would have liked.  I was not even able to mark it as fileprivate without getting an error from Realm.  Instead, I marked all properties and methods on it private and left a warning in the documentation for the class.  I was unable to think of a more complete approach to prevent client code from accessing my internal subclass.

2) To test failure on insertion, I tried using a custom Realm.Configuration that was set up as read only.  This worked most of the time, but occasionally I would get a runtime crash for an uncaught NSException.  It seems that Realm's beginWriting() method doesn't catch all NSExceptions (at least that's my current guess).  To deal with this, I added an Objective C bridging header and a little helper OjectiveCExceptions class that would catch NSExceptions thrown from Realm.beginWriting().  I'm curious if there's a better way.