### PR TITLE
Codable filesystem implementation - Anton Ilinykh

### DIFF
--- a/FeedStoreChallenge.xcodeproj/project.pbxproj
+++ b/FeedStoreChallenge.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		08CE2BB22285BCE700183A1B /* XCTestCase+FailableDeleteFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BAD2285BCE700183A1B /* XCTestCase+FailableDeleteFeedStoreSpecs.swift */; };
 		08CE2BB32285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BAE2285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift */; };
 		08CE2BB52285BEF100183A1B /* FeedStoreChallengeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CE2BB42285BEF100183A1B /* FeedStoreChallengeTests.swift */; };
+		73E91FC225D952D400191906 /* CodableFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E91FC125D952D400191906 /* CodableFeedStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		08CE2BAD2285BCE700183A1B /* XCTestCase+FailableDeleteFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableDeleteFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08CE2BAE2285BCE700183A1B /* XCTestCase+FailableInsertFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableInsertFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08CE2BB42285BEF100183A1B /* FeedStoreChallengeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreChallengeTests.swift; sourceTree = "<group>"; };
+		73E91FC125D952D400191906 /* CodableFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableFeedStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +93,7 @@
 				08CE2BA72285BCC600183A1B /* LocalFeedImage.swift */,
 				08CE2BA52285BCB600183A1B /* FeedStore.swift */,
 				08CE2B8F2285BBD100183A1B /* Info.plist */,
+				73E91FC125D952D400191906 /* CodableFeedStore.swift */,
 			);
 			path = FeedStoreChallenge;
 			sourceTree = "<group>";
@@ -231,6 +234,7 @@
 			files = (
 				08CE2BA62285BCB600183A1B /* FeedStore.swift in Sources */,
 				08CE2BA82285BCC600183A1B /* LocalFeedImage.swift in Sources */,
+				73E91FC225D952D400191906 /* CodableFeedStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FeedStoreChallenge/CodableFeedStore.swift
+++ b/FeedStoreChallenge/CodableFeedStore.swift
@@ -37,7 +37,7 @@ public class CodableFeedStore: FeedStore {
 	}
 	
 	private let storeURL: URL
-	private let queue = DispatchQueue(label: "codable-feed-store-cache.queue", qos: .userInitiated)
+	private let queue = DispatchQueue(label: "codable-feed-store-cache.queue", qos: .userInitiated, attributes: .concurrent)
 	
 	public init(storeURL: URL) {
 		self.storeURL = storeURL
@@ -45,7 +45,7 @@ public class CodableFeedStore: FeedStore {
 	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		let storeURL = self.storeURL
-		queue.async {
+		queue.async(flags: .barrier) {
 			guard FileManager.default.fileExists(atPath: storeURL.path) else {
 				return completion(nil)
 			}

--- a/FeedStoreChallenge/CodableFeedStore.swift
+++ b/FeedStoreChallenge/CodableFeedStore.swift
@@ -66,10 +66,10 @@ public class CodableFeedStore: FeedStore {
 				let cache = Cache(feed: feed.map { CodableFeedImage($0) }, timestamp: timestamp)
 				let data = try encoder.encode(cache)
 				try data.write(to: storeURL)
+				completion(nil)
 			} catch {
-				return completion(error)
+				completion(error)
 			}
-			completion(nil)
 		}
 	}
 	

--- a/FeedStoreChallenge/CodableFeedStore.swift
+++ b/FeedStoreChallenge/CodableFeedStore.swift
@@ -1,0 +1,82 @@
+//
+//  CodableFeedStore.swift
+//  FeedStoreChallenge
+//
+//  Created by Anton Ilinykh on 14.02.2021.
+//  Copyright © 2021 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+public class CodableFeedStore: FeedStore {
+	private struct Cache: Codable {
+		let feed: [CodableFeedImage]
+		let timestamp: Date
+		
+		var toLocal: [LocalFeedImage] {
+			feed.map { $0.local }
+		}
+	}
+	
+	private struct CodableFeedImage: Codable {
+		public let id: UUID
+		public let description: String?
+		public let location: String?
+		public let url: URL
+		
+		init(_ image: LocalFeedImage) {
+			self.id = image.id
+			self.description = image.description
+			self.location = image.location
+			self.url = image.url
+		}
+		
+		var local: LocalFeedImage {
+			LocalFeedImage(id: id, description: description, location: location, url: url)
+		}
+	}
+	
+	private let storeURL: URL
+	
+	public init(storeURL: URL) {
+		self.storeURL = storeURL
+	}
+	
+	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
+		guard FileManager.default.fileExists(atPath: storeURL.path) else {
+			return completion(nil)
+		}
+		do {
+			try FileManager.default.removeItem(at: storeURL)
+			completion(nil)
+		} catch {
+			completion(error)
+		}
+	}
+	
+	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
+		do {
+			let encoder = JSONEncoder()
+			let cache = Cache(feed: feed.map { CodableFeedImage($0) }, timestamp: timestamp)
+			let data = try encoder.encode(cache)
+			try data.write(to: storeURL)
+		} catch {
+			return completion(error)
+		}
+		completion(nil)
+	}
+	
+	public func retrieve(completion: @escaping RetrievalCompletion) {
+		guard let data = try? Data(contentsOf: storeURL) else {
+			return completion(.empty)
+		}
+		
+		do {
+			let decoder = JSONDecoder()
+			let cache = try decoder.decode(Cache.self, from: data)
+			completion(.found(feed: cache.toLocal, timestamp: cache.timestamp))
+		} catch {
+			completion(.failure(error))
+		}
+	}
+}

--- a/FeedStoreChallenge/CodableFeedStore.swift
+++ b/FeedStoreChallenge/CodableFeedStore.swift
@@ -37,46 +37,56 @@ public class CodableFeedStore: FeedStore {
 	}
 	
 	private let storeURL: URL
+	private let queue = DispatchQueue(label: "codable-feed-store-cache.queue", qos: .userInitiated)
 	
 	public init(storeURL: URL) {
 		self.storeURL = storeURL
 	}
 	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		guard FileManager.default.fileExists(atPath: storeURL.path) else {
-			return completion(nil)
-		}
-		do {
-			try FileManager.default.removeItem(at: storeURL)
-			completion(nil)
-		} catch {
-			completion(error)
+		let storeURL = self.storeURL
+		queue.async {
+			guard FileManager.default.fileExists(atPath: storeURL.path) else {
+				return completion(nil)
+			}
+			do {
+				try FileManager.default.removeItem(at: storeURL)
+				completion(nil)
+			} catch {
+				completion(error)
+			}
 		}
 	}
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-		do {
-			let encoder = JSONEncoder()
-			let cache = Cache(feed: feed.map { CodableFeedImage($0) }, timestamp: timestamp)
-			let data = try encoder.encode(cache)
-			try data.write(to: storeURL)
-		} catch {
-			return completion(error)
+		let storeURL = self.storeURL
+		queue.async {
+			do {
+				let encoder = JSONEncoder()
+				let cache = Cache(feed: feed.map { CodableFeedImage($0) }, timestamp: timestamp)
+				let data = try encoder.encode(cache)
+				try data.write(to: storeURL)
+			} catch {
+				return completion(error)
+			}
+			completion(nil)
 		}
-		completion(nil)
 	}
 	
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		guard let data = try? Data(contentsOf: storeURL) else {
-			return completion(.empty)
-		}
-		
-		do {
-			let decoder = JSONDecoder()
-			let cache = try decoder.decode(Cache.self, from: data)
-			completion(.found(feed: cache.toLocal, timestamp: cache.timestamp))
-		} catch {
-			completion(.failure(error))
+		let storeURL = self.storeURL
+		queue.async {
+			guard let data = try? Data(contentsOf: storeURL) else {
+				return completion(.empty)
+			}
+			
+			do {
+				let decoder = JSONDecoder()
+				let cache = try decoder.decode(Cache.self, from: data)
+				completion(.found(feed: cache.toLocal, timestamp: cache.timestamp))
+			} catch {
+				completion(.failure(error))
+			}
 		}
 	}
 }

--- a/FeedStoreChallenge/CodableFeedStore.swift
+++ b/FeedStoreChallenge/CodableFeedStore.swift
@@ -60,7 +60,7 @@ public class CodableFeedStore: FeedStore {
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
 		let storeURL = self.storeURL
-		queue.async {
+		queue.async(flags: .barrier) {
 			do {
 				let encoder = JSONEncoder()
 				let cache = Cache(feed: feed.map { CodableFeedImage($0) }, timestamp: timestamp)

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -253,9 +253,10 @@ extension FeedStoreChallengeTests: FailableDeleteFeedStoreSpecs {
 	}
 
 	func test_delete_hasNoSideEffectsOnDeletionError() {
-//		let sut = makeSUT()
-//
-//		assertThatDeleteHasNoSideEffectsOnDeletionError(on: sut)
+		let nonDeletePermissionURL = cacheDirectory()
+		let sut = makeSUT(url: nonDeletePermissionURL)
+
+		assertThatDeleteHasNoSideEffectsOnDeletionError(on: sut)
 	}
 
 }

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -80,12 +80,14 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	override func setUp() {
 		super.setUp()
-		try? FileManager.default.removeItem(at: testSpecificStoreURL())
+		
+		deleteStoreArtifacts()
 	}
 	
 	override func tearDown() {
 		super.tearDown()
-		try? FileManager.default.removeItem(at: testSpecificStoreURL())
+		
+		deleteStoreArtifacts()
 	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -168,6 +170,10 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	private func testSpecificStoreURL() -> URL {
 		FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("\(type(of: self)).cache")
+	}
+	
+	private func deleteStoreArtifacts() {
+		try? FileManager.default.removeItem(at: testSpecificStoreURL())
 	}
 }
 

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -5,81 +5,6 @@
 import XCTest
 import FeedStoreChallenge
 
-class LocalFeedStore: FeedStore {
-	private struct Cache: Codable {
-		let feed: [CodableFeedImage]
-		let timestamp: Date
-		
-		var toLocal: [LocalFeedImage] {
-			feed.map { $0.local }
-		}
-	}
-	
-	private struct CodableFeedImage: Codable {
-		public let id: UUID
-		public let description: String?
-		public let location: String?
-		public let url: URL
-		
-		init(_ image: LocalFeedImage) {
-			self.id = image.id
-			self.description = image.description
-			self.location = image.location
-			self.url = image.url
-		}
-		
-		var local: LocalFeedImage {
-			LocalFeedImage(id: id, description: description, location: location, url: url)
-		}
-	}
-	
-	let storeURL: URL
-	
-	init(storeURL: URL) {
-		self.storeURL = storeURL
-	}
-	
-	func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		guard FileManager.default.fileExists(atPath: storeURL.path) else {
-			return completion(nil)
-		}
-		do {
-			try FileManager.default.removeItem(at: storeURL)
-			completion(nil)
-		} catch {
-			completion(error)
-		}
-	}
-	
-	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-		do {
-			let encoder = JSONEncoder()
-			let cache = Cache(feed: feed.map { CodableFeedImage($0) }, timestamp: timestamp)
-			let data = try encoder.encode(cache)
-			try data.write(to: storeURL)
-		} catch {
-			return completion(error)
-		}
-		completion(nil)
-	}
-	
-	func retrieve(completion: @escaping RetrievalCompletion) {
-		guard let data = try? Data(contentsOf: storeURL) else {
-			return completion(.empty)
-		}
-		
-		do {
-			let decoder = JSONDecoder()
-			let cache = try decoder.decode(Cache.self, from: data)
-			completion(.found(feed: cache.toLocal, timestamp: cache.timestamp))
-		} catch {
-			completion(.failure(error))
-		}
-	}
-	
-	
-}
-
 class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	//  ***********************
@@ -181,7 +106,7 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	// - MARK: Helpers
 	
 	private func makeSUT(url: URL? = nil) -> FeedStore {
-		return LocalFeedStore(storeURL: url ?? testSpecificStoreURL())
+		return CodableFeedStore(storeURL: url ?? testSpecificStoreURL())
 	}
 	
 	private func testSpecificStoreURL() -> URL {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -145,9 +145,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_deliversNoErrorOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
 	}
 	
 	func test_delete_emptiesPreviouslyInsertedCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -57,9 +57,13 @@ class LocalFeedStore: FeedStore {
 			return completion(.empty)
 		}
 		
-		let decoder = JSONDecoder()
-		let cache = try! decoder.decode(Cache.self, from: data)
-		completion(.found(feed: cache.toLocal, timestamp: cache.timestamp))
+		do {
+			let decoder = JSONDecoder()
+			let cache = try decoder.decode(Cache.self, from: data)
+			completion(.found(feed: cache.toLocal, timestamp: cache.timestamp))
+		} catch {
+			completion(.failure(error))
+		}
 	}
 	
 	
@@ -186,21 +190,22 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 //
 //  ***********************
 
-//extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
+extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
+
+	func test_retrieve_deliversFailureOnRetrievalError() {
+		let sut = makeSUT()
+		try! Data("Invalid Data".utf8).write(to: testSpecificStoreURL())
+		
+		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
+	}
+
+	func test_retrieve_hasNoSideEffectsOnFailure() {
+//		let sut = makeSUT()
 //
-//	func test_retrieve_deliversFailureOnRetrievalError() {
-////		let sut = makeSUT()
-////
-////		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
-//	}
-//
-//	func test_retrieve_hasNoSideEffectsOnFailure() {
-////		let sut = makeSUT()
-////
-////		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
-//	}
-//
-//}
+//		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
+	}
+
+}
 
 //extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 //

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -40,7 +40,7 @@ class LocalFeedStore: FeedStore {
 	}
 	
 	func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		
+		completion(nil)
 	}
 	
 	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
@@ -133,9 +133,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_deliversNoErrorOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
 	}
 	
 	func test_delete_hasNoSideEffectsOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -115,9 +115,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_deliversNoErrorOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
 	}
 	
 	func test_insert_deliversNoErrorOnNonEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -224,9 +224,10 @@ extension FeedStoreChallengeTests: FailableInsertFeedStoreSpecs {
 	}
 
 	func test_insert_hasNoSideEffectsOnInsertionError() {
-//		let sut = makeSUT()
-//
-//		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
+		let invalidStoreURL = URL(string: "invalid-url://nothing")!
+		let sut = makeSUT(url: invalidStoreURL)
+
+		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
 	}
 
 }

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -121,9 +121,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_deliversNoErrorOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
 	}
 	
 	func test_insert_overridesPreviouslyInsertedCacheValues() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -158,9 +158,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_storeSideEffects_runSerially() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatSideEffectsRunSerially(on: sut)
+		let sut = makeSUT()
+		
+		assertThatSideEffectsRunSerially(on: sut)
 	}
 	
 	// - MARK: Helpers

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -5,6 +5,22 @@
 import XCTest
 import FeedStoreChallenge
 
+class LocalFeedStore: FeedStore {
+	func deleteCachedFeed(completion: @escaping DeletionCompletion) {
+		
+	}
+	
+	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
+		
+	}
+	
+	func retrieve(completion: @escaping RetrievalCompletion) {
+		completion(.empty)
+	}
+	
+	
+}
+
 class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	
 	//  ***********************
@@ -20,9 +36,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	//  ***********************
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() {
@@ -94,7 +110,7 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	// - MARK: Helpers
 	
 	private func makeSUT() -> FeedStore {
-		fatalError("Must be implemented")
+		return LocalFeedStore()
 	}
 	
 }

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -127,9 +127,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_insert_overridesPreviouslyInsertedCacheValues() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
+		let sut = makeSUT()
+		
+		assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
 	}
 	
 	func test_delete_deliversNoErrorOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -40,6 +40,7 @@ class LocalFeedStore: FeedStore {
 	}
 	
 	func deleteCachedFeed(completion: @escaping DeletionCompletion) {
+		try? FileManager.default.removeItem(at: storeURL)
 		completion(nil)
 	}
 	
@@ -151,9 +152,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_emptiesPreviouslyInsertedCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
 	}
 	
 	func test_storeSideEffects_runSerially() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -194,15 +194,18 @@ extension FeedStoreChallengeTests: FailableRetrieveFeedStoreSpecs {
 
 	func test_retrieve_deliversFailureOnRetrievalError() {
 		let sut = makeSUT()
+		
 		try! Data("Invalid Data".utf8).write(to: testSpecificStoreURL())
 		
 		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
 	}
 
 	func test_retrieve_hasNoSideEffectsOnFailure() {
-//		let sut = makeSUT()
-//
-//		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
+		let sut = makeSUT()
+		
+		try! Data("Invalid Data".utf8).write(to: testSpecificStoreURL())
+		
+		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
 	}
 
 }

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -109,9 +109,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnNonEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
 	}
 	
 	func test_insert_deliversNoErrorOnEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -42,9 +42,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
 	}
 	
 	func test_retrieve_deliversFoundValuesOnNonEmptyCache() {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -139,9 +139,9 @@ class FeedStoreChallengeTests: XCTestCase, FeedStoreSpecs {
 	}
 	
 	func test_delete_hasNoSideEffectsOnEmptyCache() {
-		//		let sut = makeSUT()
-		//
-		//		assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
+		let sut = makeSUT()
+		
+		assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
 	}
 	
 	func test_delete_deliversNoErrorOnNonEmptyCache() {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -58,15 +58,15 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_delete_deletesFeedInsertedOnAnotherInstance() {
-		//        let storeToInsert = makeSUT()
-		//        let storeToDelete = makeSUT()
-		//        let storeToLoad = makeSUT()
-		//
-		//        insert((uniqueImageFeed(), Date()), to: storeToInsert)
-		//
-		//        deleteCache(from: storeToDelete)
-		//
-		//        expect(storeToLoad, toRetrieve: .empty)
+		let storeToInsert = makeSUT()
+		let storeToDelete = makeSUT()
+		let storeToLoad = makeSUT()
+		
+		insert((uniqueImageFeed(), Date()), to: storeToInsert)
+		
+		deleteCache(from: storeToDelete)
+		
+		expect(storeToLoad, toRetrieve: .empty)
 	}
 	
 	// - MARK: Helpers

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -33,14 +33,14 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_retrieve_deliversFeedInsertedOnAnotherInstance() {
-		//        let storeToInsert = makeSUT()
-		//        let storeToLoad = makeSUT()
-		//        let feed = uniqueImageFeed()
-		//        let timestamp = Date()
-		//
-		//        insert((feed, timestamp), to: storeToInsert)
-		//
-		//        expect(storeToLoad, toRetrieve: .found(feed: feed, timestamp: timestamp))
+		let storeToInsert = makeSUT()
+		let storeToLoad = makeSUT()
+		let feed = uniqueImageFeed()
+		let timestamp = Date()
+		
+		insert((feed, timestamp), to: storeToInsert)
+		
+		expect(storeToLoad, toRetrieve: .found(feed: feed, timestamp: timestamp))
 	}
 	
 	func test_insert_overridesFeedInsertedOnAnotherInstance() {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -27,9 +27,9 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
-		//        let sut = makeSUT()
-		//
-		//        expect(sut, toRetrieve: .empty)
+		let sut = makeSUT()
+		
+		expect(sut, toRetrieve: .empty)
 	}
 	
 	func test_retrieve_deliversFeedInsertedOnAnotherInstance() {
@@ -72,7 +72,16 @@ class FeedStoreIntegrationTests: XCTestCase {
 	// - MARK: Helpers
 	
 	private func makeSUT() -> FeedStore {
-		fatalError("Must be implemented")
+		let testSpecificURL = testSpecificStoreURL()
+		return CodableFeedStore(storeURL: testSpecificURL)
+	}
+	
+	private func testSpecificStoreURL() -> URL {
+		cacheDirectory().appendingPathComponent("\(type(of: self)).cache")
+	}
+	
+	private func cacheDirectory() -> URL {
+		FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
 	}
 	
 	private func setupEmptyStoreState() {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -85,11 +85,14 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	private func setupEmptyStoreState() {
-		
+		deleteStoreArtifacts()
 	}
 	
 	private func undoStoreSideEffects() {
-		
+		deleteStoreArtifacts()
 	}
 	
+	private func deleteStoreArtifacts() {
+		try? FileManager.default.removeItem(at: testSpecificStoreURL())
+	}
 }

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -44,17 +44,17 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 	
 	func test_insert_overridesFeedInsertedOnAnotherInstance() {
-		//        let storeToInsert = makeSUT()
-		//        let storeToOverride = makeSUT()
-		//        let storeToLoad = makeSUT()
-		//
-		//        insert((uniqueImageFeed(), Date()), to: storeToInsert)
-		//
-		//        let latestFeed = uniqueImageFeed()
-		//        let latestTimestamp = Date()
-		//        insert((latestFeed, latestTimestamp), to: storeToOverride)
-		//
-		//        expect(storeToLoad, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp))
+		let storeToInsert = makeSUT()
+		let storeToOverride = makeSUT()
+		let storeToLoad = makeSUT()
+		
+		insert((uniqueImageFeed(), Date()), to: storeToInsert)
+		
+		let latestFeed = uniqueImageFeed()
+		let latestTimestamp = Date()
+		insert((latestFeed, latestTimestamp), to: storeToOverride)
+		
+		expect(storeToLoad, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp))
 	}
 	
 	func test_delete_deletesFeedInsertedOnAnotherInstance() {

--- a/Tests/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/Tests/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -106,9 +106,15 @@ extension FeedStoreSpecs where Self: XCTestCase {
 			op3.fulfill()
 		}
 		
+		let op4 = expectation(description: "Operation 4")
+		sut.retrieve(completion: { _ in
+			completedOperationsInOrder.append(op4)
+			op4.fulfill()
+		})
+		
 		waitForExpectations(timeout: 5.0)
 		
-		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
+		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3, op4], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
 	}
 	
 }

--- a/Tests/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/Tests/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -106,15 +106,9 @@ extension FeedStoreSpecs where Self: XCTestCase {
 			op3.fulfill()
 		}
 		
-		let op4 = expectation(description: "Operation 4")
-		sut.retrieve(completion: { _ in
-			completedOperationsInOrder.append(op4)
-			op4.fulfill()
-		})
-		
 		waitForExpectations(timeout: 5.0)
 		
-		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3, op4], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
+		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
 	}
 	
 }

--- a/Tests/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/Tests/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -106,9 +106,15 @@ extension FeedStoreSpecs where Self: XCTestCase {
 			op3.fulfill()
 		}
 		
+		let op4 = expectation(description: "Operation 4")
+		sut.retrieve { _ in
+			completedOperationsInOrder.append(op4)
+			op4.fulfill()
+		}
+		
 		waitForExpectations(timeout: 5.0)
 		
-		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
+		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3, op4], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
 	}
 	
 }


### PR DESCRIPTION
Hello guys!
During this challenge I discovered that there are no test for async `insert` cache operation. I mean there are already [assertThatSideEffectsRunSerially](https://github.com/essentialdevelopercom/ios-lead-essentials-feed-store-challenge/blob/master/Tests/FeedStoreSpecs/XCTestCase%2BFeedStoreSpecs.swift#L88:L107) test case but it does not cover the `insert` method without a barrier blocks around it.

You can find the details in [this](https://github.com/essentialdevelopercom/ios-lead-essentials-feed-store-challenge/pull/87/commits/1eaa3a84818a91b81c36a879926299689cd35b67) commit