### PR TITLE
Guilherme Bueno Gonçalves da Silva - Feed Store Challenge 

### DIFF
--- a/FeedStoreChallenge.xcodeproj/project.pbxproj
+++ b/FeedStoreChallenge.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		08F35C742616135B00AFE277 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F35C732616135B00AFE277 /* XCTestCase+MemoryLeakTracking.swift */; };
 		08F35C7A2616166600AFE277 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F35C772616166600AFE277 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */; };
 		08F35C7B2616166600AFE277 /* XCTestCase+FailableInsertFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F35C782616166600AFE277 /* XCTestCase+FailableInsertFeedStoreSpecs.swift */; };
+		C7E1DCC32651A6F20041E7E2 /* FeedStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C7E1DCC12651A6F20041E7E2 /* FeedStore.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		08F35C732616135B00AFE277 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		08F35C772616166600AFE277 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableRetrieveFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08F35C782616166600AFE277 /* XCTestCase+FailableInsertFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableInsertFeedStoreSpecs.swift"; sourceTree = "<group>"; };
+		C7E1DCC22651A6F20041E7E2 /* FeedStore.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = FeedStore.xcdatamodel; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +104,7 @@
 		08CE2B8D2285BBD100183A1B /* FeedStoreChallenge */ = {
 			isa = PBXGroup;
 			children = (
+				C7E1DCC12651A6F20041E7E2 /* FeedStore.xcdatamodeld */,
 				08CB21E1261638BA00751C29 /* Helpers */,
 				08CE2BA72285BCC600183A1B /* LocalFeedImage.swift */,
 				08CE2BA52285BCB600183A1B /* FeedStore.swift */,
@@ -277,6 +280,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08CB21D1261632DB00751C29 /* CoreDataHelpers.swift in Sources */,
+				C7E1DCC32651A6F20041E7E2 /* FeedStore.xcdatamodeld in Sources */,
 				08F35C6F261612AE00AFE277 /* CoreDataFeedStore.swift in Sources */,
 				08CE2BA62285BCB600183A1B /* FeedStore.swift in Sources */,
 				08CE2BA82285BCC600183A1B /* LocalFeedImage.swift in Sources */,
@@ -559,6 +563,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		C7E1DCC12651A6F20041E7E2 /* FeedStore.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				C7E1DCC22651A6F20041E7E2 /* FeedStore.xcdatamodel */,
+			);
+			currentVersion = C7E1DCC22651A6F20041E7E2 /* FeedStore.xcdatamodel */;
+			path = FeedStore.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 08CE2B822285BBD100183A1B /* Project object */;
 }

--- a/FeedStoreChallenge.xcodeproj/project.pbxproj
+++ b/FeedStoreChallenge.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		08F35C742616135B00AFE277 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F35C732616135B00AFE277 /* XCTestCase+MemoryLeakTracking.swift */; };
 		08F35C7A2616166600AFE277 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F35C772616166600AFE277 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */; };
 		08F35C7B2616166600AFE277 /* XCTestCase+FailableInsertFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F35C782616166600AFE277 /* XCTestCase+FailableInsertFeedStoreSpecs.swift */; };
+		C745CE072651C61D000AF8E5 /* CoreDataFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = C745CE062651C61D000AF8E5 /* CoreDataFeed.swift */; };
+		C745CE092651C64B000AF8E5 /* CoreDataFeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C745CE082651C64B000AF8E5 /* CoreDataFeedImage.swift */; };
+		C745CE0B2651C6F8000AF8E5 /* LocalFeedImage+CoreDataMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C745CE0A2651C6F8000AF8E5 /* LocalFeedImage+CoreDataMap.swift */; };
 		C7E1DCC32651A6F20041E7E2 /* FeedStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C7E1DCC12651A6F20041E7E2 /* FeedStore.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
@@ -52,6 +55,9 @@
 		08F35C732616135B00AFE277 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		08F35C772616166600AFE277 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableRetrieveFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		08F35C782616166600AFE277 /* XCTestCase+FailableInsertFeedStoreSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableInsertFeedStoreSpecs.swift"; sourceTree = "<group>"; };
+		C745CE062651C61D000AF8E5 /* CoreDataFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataFeed.swift; sourceTree = "<group>"; };
+		C745CE082651C64B000AF8E5 /* CoreDataFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataFeedImage.swift; sourceTree = "<group>"; };
+		C745CE0A2651C6F8000AF8E5 /* LocalFeedImage+CoreDataMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalFeedImage+CoreDataMap.swift"; sourceTree = "<group>"; };
 		C7E1DCC22651A6F20041E7E2 /* FeedStore.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = FeedStore.xcdatamodel; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -78,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				08CB21D0261632DB00751C29 /* CoreDataHelpers.swift */,
+				C745CE0A2651C6F8000AF8E5 /* LocalFeedImage+CoreDataMap.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -104,6 +111,7 @@
 		08CE2B8D2285BBD100183A1B /* FeedStoreChallenge */ = {
 			isa = PBXGroup;
 			children = (
+				C745CE052651C615000AF8E5 /* CoreDataModels */,
 				C7E1DCC12651A6F20041E7E2 /* FeedStore.xcdatamodeld */,
 				08CB21E1261638BA00751C29 /* Helpers */,
 				08CE2BA72285BCC600183A1B /* LocalFeedImage.swift */,
@@ -145,6 +153,15 @@
 				08CB21DD2616389100751C29 /* NSManagedObjectContext+Stub.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		C745CE052651C615000AF8E5 /* CoreDataModels */ = {
+			isa = PBXGroup;
+			children = (
+				C745CE062651C61D000AF8E5 /* CoreDataFeed.swift */,
+				C745CE082651C64B000AF8E5 /* CoreDataFeedImage.swift */,
+			);
+			path = CoreDataModels;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -281,6 +298,9 @@
 			files = (
 				08CB21D1261632DB00751C29 /* CoreDataHelpers.swift in Sources */,
 				C7E1DCC32651A6F20041E7E2 /* FeedStore.xcdatamodeld in Sources */,
+				C745CE0B2651C6F8000AF8E5 /* LocalFeedImage+CoreDataMap.swift in Sources */,
+				C745CE092651C64B000AF8E5 /* CoreDataFeedImage.swift in Sources */,
+				C745CE072651C61D000AF8E5 /* CoreDataFeed.swift in Sources */,
 				08F35C6F261612AE00AFE277 /* CoreDataFeedStore.swift in Sources */,
 				08CE2BA62285BCB600183A1B /* FeedStore.swift in Sources */,
 				08CE2BA82285BCC600183A1B /* LocalFeedImage.swift in Sources */,

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -29,7 +29,7 @@ public final class CoreDataFeedStore: FeedStore {
 	}
 
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		fatalError("Must be implemented")
+		completion(.empty)
 	}
 
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -62,6 +62,7 @@ public final class CoreDataFeedStore: FeedStore {
 				try context.save()
 				completion(nil)
 			} catch {
+				context.rollback()
 				completion(error)
 			}
 		}

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -69,6 +69,6 @@ public final class CoreDataFeedStore: FeedStore {
 	}
 
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		fatalError("Must be implemented")
+		completion(nil)
 	}
 }

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -73,7 +73,9 @@ public final class CoreDataFeedStore: FeedStore {
 				try context.execute(CoreDataFeed.defaultDeleteRequest)
 				try context.save()
 				completion(nil)
-			} catch {}
+			} catch {
+				completion(error)
+			}
 		}
 	}
 }

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -70,10 +70,17 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				try context.execute(CoreDataFeed.defaultDeleteRequest)
-				try context.save()
-				completion(nil)
+				let result = try context.fetch(CoreDataFeed.defaultFetchRequest)
+
+				if let feed = result.first as? NSManagedObject {
+					context.delete(feed)
+					try context.save()
+					completion(nil)
+				} else {
+					completion(nil)
+				}
 			} catch {
+				context.rollback()
 				completion(error)
 			}
 		}

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -56,6 +56,10 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
+				let request = NSFetchRequest<NSFetchRequestResult>(entityName: CoreDataFeed.className())
+				let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+
+				try context.execute(deleteRequest)
 				CoreDataFeed.createCoreDataFeed(feed, with: timestamp, in: context)
 				try context.save()
 				completion(nil)

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -55,7 +55,12 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				try context.execute(CoreDataFeed.defaultDeleteRequest)
+				let result = try context.fetch(CoreDataFeed.defaultFetchRequest)
+
+				if let feed = result.first as? NSManagedObject {
+					context.delete(feed)
+				}
+
 				CoreDataFeed.createCoreDataFeed(feed, with: timestamp, in: context)
 				try context.save()
 				completion(nil)

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -32,8 +32,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = context
 		context.perform {
 			do {
-				let request = NSFetchRequest<NSFetchRequestResult>(entityName: CoreDataFeed.className())
-				let result = try context.fetch(request)
+				let result = try context.fetch(CoreDataFeed.defaultFetchRequest)
 
 				if let feed = result.first as? CoreDataFeed {
 					completion(
@@ -56,8 +55,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				let request = NSFetchRequest<NSFetchRequestResult>(entityName: CoreDataFeed.className())
-				let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+				let deleteRequest = NSBatchDeleteRequest(fetchRequest: CoreDataFeed.defaultFetchRequest)
 
 				try context.execute(deleteRequest)
 				CoreDataFeed.createCoreDataFeed(feed, with: timestamp, in: context)

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -4,21 +4,6 @@
 
 import CoreData
 
-@objc(CoreDataFeed)
-class CoreDataFeed: NSManagedObject {
-	@NSManaged public var timestamp: Date
-	@NSManaged public var feedImages: NSOrderedSet
-}
-
-@objc(CoreDataFeedImage)
-class CoreDataFeedImage: NSManagedObject {
-	@NSManaged var id: UUID
-	@NSManaged var imageDescription: String?
-	@NSManaged var location: String?
-	@NSManaged var url: URL
-	@NSManaged var feed: CoreDataFeed
-}
-
 public final class CoreDataFeedStore: FeedStore {
 	private static let modelName = "FeedStore"
 	private static let model = NSManagedObjectModel(name: modelName, in: Bundle(for: CoreDataFeedStore.self))
@@ -53,7 +38,7 @@ public final class CoreDataFeedStore: FeedStore {
 				if let feed = result.first as? CoreDataFeed {
 					completion(
 						.found(
-							feed: feed.feedImagesArray().map { $0.mapToLocalFeedImage() },
+							feed: feed.localFeedImages(),
 							timestamp: feed.timestamp
 						)
 					)
@@ -71,7 +56,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				_ = feed.createCoreDataFeed(with: timestamp, in: context)
+				CoreDataFeed.createCoreDataFeed(feed, with: timestamp, in: context)
 				try context.save()
 				completion(nil)
 			} catch {
@@ -82,45 +67,5 @@ public final class CoreDataFeedStore: FeedStore {
 
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		fatalError("Must be implemented")
-	}
-}
-
-extension CoreDataFeed {
-	func feedImagesArray() -> [CoreDataFeedImage] {
-		feedImages.compactMap { image in
-			return image as? CoreDataFeedImage ?? nil
-		}
-	}
-}
-
-extension Collection where Element == LocalFeedImage {
-	func createCoreDataFeed(with timestamp: Date, in context: NSManagedObjectContext) -> CoreDataFeed {
-		let feed = CoreDataFeed(context: context)
-		let feedImagesSet = NSOrderedSet(array: map { $0.mapToCoreData(in: context) })
-		feed.timestamp = timestamp
-		feed.feedImages = feedImagesSet
-		return feed
-	}
-}
-
-extension CoreDataFeedImage {
-	func mapToLocalFeedImage() -> LocalFeedImage {
-		return LocalFeedImage(
-			id: id,
-			description: imageDescription,
-			location: location,
-			url: url
-		)
-	}
-}
-
-extension LocalFeedImage {
-	func mapToCoreData(in context: NSManagedObjectContext) -> CoreDataFeedImage {
-		let feedImage = CoreDataFeedImage(context: context)
-		feedImage.id = id
-		feedImage.imageDescription = description
-		feedImage.location = location
-		feedImage.url = url.absoluteURL
-		return feedImage
 	}
 }

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -53,10 +53,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				if let feed = try CoreDataFeed.first(in: context) {
-					context.delete(feed)
-				}
-
+				try CoreDataFeed.deleteFirst(in: context)
 				CoreDataFeed.createCoreDataFeed(feed, with: timestamp, in: context)
 				try context.save()
 				completion(nil)
@@ -71,11 +68,8 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				if let feed = try CoreDataFeed.first(in: context) {
-					context.delete(feed)
-					try context.save()
-				}
-
+				try CoreDataFeed.deleteFirst(in: context)
+				try context.save()
 				completion(nil)
 			} catch {
 				context.rollback()

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -32,17 +32,14 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = context
 		context.perform {
 			do {
-				if let feed = try CoreDataFeed.first(in: context) {
-					completion(
-						.found(
-							feed: feed.localFeedImages(),
-							timestamp: feed.timestamp
-						)
-					)
-				} else {
+				guard let feed = try CoreDataFeed.first(in: context) else {
 					completion(.empty)
 					return
 				}
+
+				completion(
+					.found(feed: feed.localFeedImages(), timestamp: feed.timestamp)
+				)
 			} catch {
 				completion(.failure(error))
 			}

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -69,6 +69,15 @@ public final class CoreDataFeedStore: FeedStore {
 	}
 
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		completion(nil)
+		let context = self.context
+		context.perform {
+			do {
+				let deleteRequest = NSBatchDeleteRequest(fetchRequest: CoreDataFeed.defaultFetchRequest)
+
+				try context.execute(deleteRequest)
+				try context.save()
+				completion(nil)
+			} catch {}
+		}
 	}
 }

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -32,9 +32,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = context
 		context.perform {
 			do {
-				let result = try context.fetch(CoreDataFeed.defaultFetchRequest)
-
-				if let feed = result.first as? CoreDataFeed {
+				if let feed = try CoreDataFeed.first(in: context) {
 					completion(
 						.found(
 							feed: feed.localFeedImages(),
@@ -55,9 +53,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				let result = try context.fetch(CoreDataFeed.defaultFetchRequest)
-
-				if let feed = result.first as? NSManagedObject {
+				if let feed = try CoreDataFeed.first(in: context) {
 					context.delete(feed)
 				}
 
@@ -75,9 +71,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				let result = try context.fetch(CoreDataFeed.defaultFetchRequest)
-
-				if let feed = result.first as? NSManagedObject {
+				if let feed = try CoreDataFeed.first(in: context) {
 					context.delete(feed)
 					try context.save()
 					completion(nil)

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -4,6 +4,21 @@
 
 import CoreData
 
+@objc(CoreDataFeed)
+class CoreDataFeed: NSManagedObject {
+	@NSManaged public var timestamp: Date
+	@NSManaged public var feedImages: NSOrderedSet
+}
+
+@objc(CoreDataFeedImage)
+class CoreDataFeedImage: NSManagedObject {
+	@NSManaged var id: UUID
+	@NSManaged var imageDescription: String?
+	@NSManaged var location: String?
+	@NSManaged var url: URL
+	@NSManaged var feed: CoreDataFeed
+}
+
 public final class CoreDataFeedStore: FeedStore {
 	private static let modelName = "FeedStore"
 	private static let model = NSManagedObjectModel(name: modelName, in: Bundle(for: CoreDataFeedStore.self))
@@ -29,14 +44,83 @@ public final class CoreDataFeedStore: FeedStore {
 	}
 
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		completion(.empty)
+		let context = context
+		context.perform {
+			do {
+				let request = NSFetchRequest<NSFetchRequestResult>(entityName: CoreDataFeed.className())
+				let result = try context.fetch(request)
+
+				if let feed = result.first as? CoreDataFeed {
+					completion(
+						.found(
+							feed: feed.feedImagesArray().map { $0.mapToLocalFeedImage() },
+							timestamp: feed.timestamp
+						)
+					)
+				} else {
+					completion(.empty)
+					return
+				}
+			} catch {
+				completion(.failure(error))
+			}
+		}
 	}
 
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-		fatalError("Must be implemented")
+		let context = self.context
+		context.perform {
+			do {
+				_ = feed.createCoreDataFeed(with: timestamp, in: context)
+				try context.save()
+				completion(nil)
+			} catch {
+				completion(error)
+			}
+		}
 	}
 
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		fatalError("Must be implemented")
+	}
+}
+
+extension CoreDataFeed {
+	func feedImagesArray() -> [CoreDataFeedImage] {
+		feedImages.compactMap { image in
+			return image as? CoreDataFeedImage ?? nil
+		}
+	}
+}
+
+extension Collection where Element == LocalFeedImage {
+	func createCoreDataFeed(with timestamp: Date, in context: NSManagedObjectContext) -> CoreDataFeed {
+		let feed = CoreDataFeed(context: context)
+		let feedImagesSet = NSOrderedSet(array: map { $0.mapToCoreData(in: context) })
+		feed.timestamp = timestamp
+		feed.feedImages = feedImagesSet
+		return feed
+	}
+}
+
+extension CoreDataFeedImage {
+	func mapToLocalFeedImage() -> LocalFeedImage {
+		return LocalFeedImage(
+			id: id,
+			description: imageDescription,
+			location: location,
+			url: url
+		)
+	}
+}
+
+extension LocalFeedImage {
+	func mapToCoreData(in context: NSManagedObjectContext) -> CoreDataFeedImage {
+		let feedImage = CoreDataFeedImage(context: context)
+		feedImage.id = id
+		feedImage.imageDescription = description
+		feedImage.location = location
+		feedImage.url = url.absoluteURL
+		return feedImage
 	}
 }

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -74,10 +74,9 @@ public final class CoreDataFeedStore: FeedStore {
 				if let feed = try CoreDataFeed.first(in: context) {
 					context.delete(feed)
 					try context.save()
-					completion(nil)
-				} else {
-					completion(nil)
 				}
+
+				completion(nil)
 			} catch {
 				context.rollback()
 				completion(error)

--- a/FeedStoreChallenge/CoreDataFeedStore.swift
+++ b/FeedStoreChallenge/CoreDataFeedStore.swift
@@ -55,9 +55,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				let deleteRequest = NSBatchDeleteRequest(fetchRequest: CoreDataFeed.defaultFetchRequest)
-
-				try context.execute(deleteRequest)
+				try context.execute(CoreDataFeed.defaultDeleteRequest)
 				CoreDataFeed.createCoreDataFeed(feed, with: timestamp, in: context)
 				try context.save()
 				completion(nil)
@@ -72,9 +70,7 @@ public final class CoreDataFeedStore: FeedStore {
 		let context = self.context
 		context.perform {
 			do {
-				let deleteRequest = NSBatchDeleteRequest(fetchRequest: CoreDataFeed.defaultFetchRequest)
-
-				try context.execute(deleteRequest)
+				try context.execute(CoreDataFeed.defaultDeleteRequest)
 				try context.save()
 				completion(nil)
 			} catch {}

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
@@ -1,0 +1,31 @@
+//
+//  CoreDataFeed.swift
+//  FeedStoreChallenge
+//
+//  Created by Guilherme Bueno on 16/05/21.
+//  Copyright © 2021 Essential Developer. All rights reserved.
+//
+
+import CoreData
+
+@objc(CoreDataFeed)
+class CoreDataFeed: NSManagedObject {
+	@NSManaged public var timestamp: Date
+	@NSManaged public var feedImages: NSOrderedSet
+}
+
+extension CoreDataFeed {
+	func localFeedImages() -> [LocalFeedImage] {
+		feedImages.compactMap { image in
+			return (image as? CoreDataFeedImage)?.mapToLocalFeedImage()
+		}
+	}
+
+	@discardableResult
+	static func createCoreDataFeed(_ feed: [LocalFeedImage], with timestamp: Date, in context: NSManagedObjectContext) -> CoreDataFeed {
+		let coreDataFeed = CoreDataFeed(context: context)
+		coreDataFeed.timestamp = timestamp
+		coreDataFeed.feedImages = NSOrderedSet(array: feed.map { $0.mapToCoreData(in: context) })
+		return coreDataFeed
+	}
+}

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
@@ -19,6 +19,10 @@ extension CoreDataFeed {
 		return NSFetchRequest(entityName: CoreDataFeed.className())
 	}
 
+	static func first(in context: NSManagedObjectContext) throws -> CoreDataFeed? {
+		return try context.fetch(CoreDataFeed.defaultFetchRequest).first as? CoreDataFeed
+	}
+
 	func localFeedImages() -> [LocalFeedImage] {
 		feedImages.compactMap { image in
 			return (image as? CoreDataFeedImage)?.mapToLocalFeedImage()

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
@@ -15,6 +15,10 @@ class CoreDataFeed: NSManagedObject {
 }
 
 extension CoreDataFeed {
+	static var defaultFetchRequest: NSFetchRequest<NSFetchRequestResult> {
+		return NSFetchRequest(entityName: CoreDataFeed.className())
+	}
+
 	func localFeedImages() -> [LocalFeedImage] {
 		feedImages.compactMap { image in
 			return (image as? CoreDataFeedImage)?.mapToLocalFeedImage()

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
@@ -23,6 +23,12 @@ extension CoreDataFeed {
 		return try context.fetch(CoreDataFeed.defaultFetchRequest).first as? CoreDataFeed
 	}
 
+	static func deleteFirst(in context: NSManagedObjectContext) throws {
+		if let feed = try CoreDataFeed.first(in: context) {
+			context.delete(feed)
+		}
+	}
+
 	func localFeedImages() -> [LocalFeedImage] {
 		feedImages.compactMap { image in
 			return (image as? CoreDataFeedImage)?.mapToLocalFeedImage()

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
@@ -19,10 +19,6 @@ extension CoreDataFeed {
 		return NSFetchRequest(entityName: CoreDataFeed.className())
 	}
 
-	static var defaultDeleteRequest: NSBatchDeleteRequest {
-		return NSBatchDeleteRequest(fetchRequest: CoreDataFeed.defaultFetchRequest)
-	}
-
 	func localFeedImages() -> [LocalFeedImage] {
 		feedImages.compactMap { image in
 			return (image as? CoreDataFeedImage)?.mapToLocalFeedImage()

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeed.swift
@@ -19,6 +19,10 @@ extension CoreDataFeed {
 		return NSFetchRequest(entityName: CoreDataFeed.className())
 	}
 
+	static var defaultDeleteRequest: NSBatchDeleteRequest {
+		return NSBatchDeleteRequest(fetchRequest: CoreDataFeed.defaultFetchRequest)
+	}
+
 	func localFeedImages() -> [LocalFeedImage] {
 		feedImages.compactMap { image in
 			return (image as? CoreDataFeedImage)?.mapToLocalFeedImage()

--- a/FeedStoreChallenge/CoreDataModels/CoreDataFeedImage.swift
+++ b/FeedStoreChallenge/CoreDataModels/CoreDataFeedImage.swift
@@ -1,0 +1,29 @@
+//
+//  CoreDataFeedImage.swift
+//  FeedStoreChallenge
+//
+//  Created by Guilherme Bueno on 16/05/21.
+//  Copyright © 2021 Essential Developer. All rights reserved.
+//
+
+import CoreData
+
+@objc(CoreDataFeedImage)
+class CoreDataFeedImage: NSManagedObject {
+	@NSManaged var id: UUID
+	@NSManaged var imageDescription: String?
+	@NSManaged var location: String?
+	@NSManaged var url: URL
+	@NSManaged var feed: CoreDataFeed
+}
+
+extension CoreDataFeedImage {
+	func mapToLocalFeedImage() -> LocalFeedImage {
+		return LocalFeedImage(
+			id: id,
+			description: imageDescription,
+			location: location,
+			url: url
+		)
+	}
+}

--- a/FeedStoreChallenge/FeedStore.xcdatamodeld/FeedStore.xcdatamodel/contents
+++ b/FeedStoreChallenge/FeedStore.xcdatamodeld/FeedStore.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E241" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <elements/>
+</model>

--- a/FeedStoreChallenge/FeedStore.xcdatamodeld/FeedStore.xcdatamodel/contents
+++ b/FeedStoreChallenge/FeedStore.xcdatamodeld/FeedStore.xcdatamodel/contents
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E241" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <elements/>
+    <entity name="CoreDataFeed" representedClassName="CoreDataFeed" syncable="YES">
+        <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="feedImages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="CoreDataFeedImage" inverseName="feed" inverseEntity="CoreDataFeedImage"/>
+    </entity>
+    <entity name="CoreDataFeedImage" representedClassName="CoreDataFeedImage" syncable="YES">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="imageDescription" optional="YES" attributeType="String"/>
+        <attribute name="location" optional="YES" attributeType="String"/>
+        <attribute name="url" attributeType="URI"/>
+        <relationship name="feed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CoreDataFeed" inverseName="feedImages" inverseEntity="CoreDataFeed"/>
+    </entity>
+    <elements>
+        <element name="CoreDataFeed" positionX="-54" positionY="18" width="128" height="59"/>
+        <element name="CoreDataFeedImage" positionX="-54" positionY="0" width="128" height="104"/>
+    </elements>
 </model>

--- a/FeedStoreChallenge/Helpers/LocalFeedImage+CoreDataMap.swift
+++ b/FeedStoreChallenge/Helpers/LocalFeedImage+CoreDataMap.swift
@@ -1,0 +1,20 @@
+//
+//  LocalFeedImage+CoreDataMap.swift
+//  FeedStoreChallenge
+//
+//  Created by Guilherme Bueno on 16/05/21.
+//  Copyright © 2021 Essential Developer. All rights reserved.
+//
+
+import CoreData
+
+extension LocalFeedImage {
+	func mapToCoreData(in context: NSManagedObjectContext) -> CoreDataFeedImage {
+		let feedImage = CoreDataFeedImage(context: context)
+		feedImage.id = id
+		feedImage.imageDescription = description
+		feedImage.location = location
+		feedImage.url = url.absoluteURL
+		return feedImage
+	}
+}

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -109,9 +109,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_delete_deliversNoErrorOnNonEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatDeleteDeliversNoErrorOnNonEmptyCache(on: sut)
 	}
 
 	func test_delete_emptiesPreviouslyInsertedCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -52,12 +52,12 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_retrieve_hasNoSideEffectsOnFailure() throws {
-//		let stub = NSManagedObjectContext.alwaysFailingFetchStub()
-//		stub.startIntercepting()
-//
-//		let sut = try makeSUT()
-//
-//		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
+		let stub = NSManagedObjectContext.alwaysFailingFetchStub()
+		stub.startIntercepting()
+
+		let sut = try makeSUT()
+
+		assertThatRetrieveHasNoSideEffectsOnFailure(on: sut)
 	}
 
 	func test_insert_deliversNoErrorOnEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -97,9 +97,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_delete_deliversNoErrorOnEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatDeleteDeliversNoErrorOnEmptyCache(on: sut)
 	}
 
 	func test_delete_hasNoSideEffectsOnEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -115,9 +115,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_delete_emptiesPreviouslyInsertedCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
 	}
 
 	func test_delete_deliversErrorOnDeletionError() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -136,18 +136,18 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_delete_hasNoSideEffectsOnDeletionError() throws {
-//		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
-//		let feed = uniqueImageFeed()
-//		let timestamp = Date()
-//		let sut = try makeSUT()
-//
-//		insert((feed, timestamp), to: sut)
-//
-//		stub.startIntercepting()
-//
-//		deleteCache(from: sut)
-//
-//		expect(sut, toRetrieve: .found(feed: feed, timestamp: timestamp))
+		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
+		let feed = uniqueImageFeed()
+		let timestamp = Date()
+		let sut = try makeSUT()
+
+		insert((feed, timestamp), to: sut)
+
+		stub.startIntercepting()
+
+		deleteCache(from: sut)
+
+		expect(sut, toRetrieve: .found(feed: feed, timestamp: timestamp))
 	}
 
 	func test_storeSideEffects_runSerially() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -79,12 +79,12 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_insert_deliversErrorOnInsertionError() throws {
-//		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
-//		stub.startIntercepting()
-//
-//		let sut = try makeSUT()
-//
-//		assertThatInsertDeliversErrorOnInsertionError(on: sut)
+		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
+		stub.startIntercepting()
+
+		let sut = try makeSUT()
+
+		assertThatInsertDeliversErrorOnInsertionError(on: sut)
 	}
 
 	func test_insert_hasNoSideEffectsOnInsertionError() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -43,12 +43,12 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_retrieve_deliversFailureOnRetrievalError() throws {
-//		let stub = NSManagedObjectContext.alwaysFailingFetchStub()
-//		stub.startIntercepting()
-//
-//		let sut = try makeSUT()
-//
-//		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
+		let stub = NSManagedObjectContext.alwaysFailingFetchStub()
+		stub.startIntercepting()
+
+		let sut = try makeSUT()
+
+		assertThatRetrieveDeliversFailureOnRetrievalError(on: sut)
 	}
 
 	func test_retrieve_hasNoSideEffectsOnFailure() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -61,9 +61,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_insert_deliversNoErrorOnEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatInsertDeliversNoErrorOnEmptyCache(on: sut)
 	}
 
 	func test_insert_deliversNoErrorOnNonEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -121,18 +121,18 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_delete_deliversErrorOnDeletionError() throws {
-//		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
-//		let feed = uniqueImageFeed()
-//		let timestamp = Date()
-//		let sut = try makeSUT()
-//
-//		insert((feed, timestamp), to: sut)
-//
-//		stub.startIntercepting()
-//
-//		let deletionError = deleteCache(from: sut)
-//
-//		XCTAssertNotNil(deletionError, "Expected cache deletion to fail")
+		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
+		let feed = uniqueImageFeed()
+		let timestamp = Date()
+		let sut = try makeSUT()
+
+		insert((feed, timestamp), to: sut)
+
+		stub.startIntercepting()
+
+		let deletionError = deleteCache(from: sut)
+
+		XCTAssertNotNil(deletionError, "Expected cache deletion to fail")
 	}
 
 	func test_delete_hasNoSideEffectsOnDeletionError() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -88,12 +88,12 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_insert_hasNoSideEffectsOnInsertionError() throws {
-//		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
-//		stub.startIntercepting()
-//
-//		let sut = try makeSUT()
-//
-//		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
+		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
+		stub.startIntercepting()
+
+		let sut = try makeSUT()
+
+		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
 	}
 
 	func test_delete_deliversNoErrorOnEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -73,9 +73,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_insert_overridesPreviouslyInsertedCacheValues() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
+		let sut = try makeSUT()
+
+		assertThatInsertOverridesPreviouslyInsertedCacheValues(on: sut)
 	}
 
 	func test_insert_deliversErrorOnInsertionError() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -37,9 +37,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_retrieve_hasNoSideEffectsOnNonEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on: sut)
 	}
 
 	func test_retrieve_deliversFailureOnRetrievalError() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -19,9 +19,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	//  ***********************
 
 	func test_retrieve_deliversEmptyOnEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatRetrieveDeliversEmptyOnEmptyCache(on: sut)
 	}
 
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -31,9 +31,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_retrieve_deliversFoundValuesOnNonEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on: sut)
 	}
 
 	func test_retrieve_hasNoSideEffectsOnNonEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -151,9 +151,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_storeSideEffects_runSerially() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatSideEffectsRunSerially(on: sut)
+		let sut = try makeSUT()
+
+		assertThatSideEffectsRunSerially(on: sut)
 	}
 
 	// - MARK: Helpers

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -103,9 +103,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_delete_hasNoSideEffectsOnEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatDeleteHasNoSideEffectsOnEmptyCache(on: sut)
 	}
 
 	func test_delete_deliversNoErrorOnNonEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -25,9 +25,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatRetrieveHasNoSideEffectsOnEmptyCache(on: sut)
 	}
 
 	func test_retrieve_deliversFoundValuesOnNonEmptyCache() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -67,9 +67,9 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 	}
 
 	func test_insert_deliversNoErrorOnNonEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
+		let sut = try makeSUT()
+
+		assertThatInsertDeliversNoErrorOnNonEmptyCache(on: sut)
 	}
 
 	func test_insert_overridesPreviouslyInsertedCacheValues() throws {

--- a/Tests/FeedStoreChallengeTests.swift
+++ b/Tests/FeedStoreChallengeTests.swift
@@ -96,6 +96,23 @@ class FeedStoreChallengeTests: XCTestCase, FailableFeedStoreSpecs {
 		assertThatInsertHasNoSideEffectsOnInsertionError(on: sut)
 	}
 
+	func test_insert_hasNoSideEffectsOnInsertionErrorWhenThereIsCache() throws {
+		let stub = NSManagedObjectContext.alwaysFailingSaveStub()
+		let initiallyCachedFeed = uniqueImageFeed()
+		let initialTimestamp = Date()
+		let sut = try makeSUT()
+
+		insert((initiallyCachedFeed, initialTimestamp), to: sut)
+
+		stub.startIntercepting()
+
+		let newFeed = uniqueImageFeed()
+		let newTimestamp = Date()
+		insert((newFeed, newTimestamp), to: sut)
+
+		expect(sut, toRetrieve: .found(feed: initiallyCachedFeed, timestamp: initialTimestamp))
+	}
+
 	func test_delete_deliversNoErrorOnEmptyCache() throws {
 		let sut = try makeSUT()
 

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -40,14 +40,14 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 
 	func test_retrieve_deliversFeedInsertedOnAnotherInstance() throws {
-//		let storeToInsert = try makeSUT()
-//		let storeToLoad = try makeSUT()
-//		let feed = uniqueImageFeed()
-//		let timestamp = Date()
-//
-//		insert((feed, timestamp), to: storeToInsert)
-//
-//		expect(storeToLoad, toRetrieve: .found(feed: feed, timestamp: timestamp))
+		let storeToInsert = try makeSUT()
+		let storeToLoad = try makeSUT()
+		let feed = uniqueImageFeed()
+		let timestamp = Date()
+
+		insert((feed, timestamp), to: storeToInsert)
+
+		expect(storeToLoad, toRetrieve: .found(feed: feed, timestamp: timestamp))
 	}
 
 	func test_insert_overridesFeedInsertedOnAnotherInstance() throws {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -34,9 +34,9 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 
 	func test_retrieve_deliversEmptyOnEmptyCache() throws {
-//		let sut = try makeSUT()
-//
-//		expect(sut, toRetrieve: .empty)
+		let sut = try makeSUT()
+
+		expect(sut, toRetrieve: .empty)
 	}
 
 	func test_retrieve_deliversFeedInsertedOnAnotherInstance() throws {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -51,17 +51,17 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 
 	func test_insert_overridesFeedInsertedOnAnotherInstance() throws {
-//		let storeToInsert = try makeSUT()
-//		let storeToOverride = try makeSUT()
-//		let storeToLoad = try makeSUT()
-//
-//		insert((uniqueImageFeed(), Date()), to: storeToInsert)
-//
-//		let latestFeed = uniqueImageFeed()
-//		let latestTimestamp = Date()
-//		insert((latestFeed, latestTimestamp), to: storeToOverride)
-//
-//		expect(storeToLoad, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp))
+		let storeToInsert = try makeSUT()
+		let storeToOverride = try makeSUT()
+		let storeToLoad = try makeSUT()
+
+		insert((uniqueImageFeed(), Date()), to: storeToInsert)
+
+		let latestFeed = uniqueImageFeed()
+		let latestTimestamp = Date()
+		insert((latestFeed, latestTimestamp), to: storeToOverride)
+
+		expect(storeToLoad, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp))
 	}
 
 	func test_delete_deletesFeedInsertedOnAnotherInstance() throws {

--- a/Tests/FeedStoreIntegrationTests.swift
+++ b/Tests/FeedStoreIntegrationTests.swift
@@ -65,15 +65,15 @@ class FeedStoreIntegrationTests: XCTestCase {
 	}
 
 	func test_delete_deletesFeedInsertedOnAnotherInstance() throws {
-//		let storeToInsert = try makeSUT()
-//		let storeToDelete = try makeSUT()
-//		let storeToLoad = try makeSUT()
-//
-//		insert((uniqueImageFeed(), Date()), to: storeToInsert)
-//
-//		deleteCache(from: storeToDelete)
-//
-//		expect(storeToLoad, toRetrieve: .empty)
+		let storeToInsert = try makeSUT()
+		let storeToDelete = try makeSUT()
+		let storeToLoad = try makeSUT()
+
+		insert((uniqueImageFeed(), Date()), to: storeToInsert)
+
+		deleteCache(from: storeToDelete)
+
+		expect(storeToLoad, toRetrieve: .empty)
 	}
 
 	// - MARK: Helpers


### PR DESCRIPTION
I added a test to check if a previously saved cache remains when an insertion fails in this commit `9649f8ad799a6f563f57aee7a913fbb50adeb9bd`.
The side effects tests wasn't checking for that, it was just checking if the cache was empty. 
I found that side effect because I was using a delete batch request instead of deleting the feed object and then the rollback wasn't working.


